### PR TITLE
Add cadair.theme meta file

### DIFF
--- a/cadair.theme
+++ b/cadair.theme
@@ -1,0 +1,7 @@
+[Theme]
+engine = mako
+parent = bootstrap3
+author = Stuart Mumford
+author_url = http://www.stuartmumford.co.uk
+license = MIT
+tags = bootstrap


### PR DESCRIPTION
Hi there,
this PR adds a .theme meta file, for the use of Nikola and the new themes.getnikola.com site.

On a side note, could we please take the theme and put it in the `getnikola/nikola-themes` repo, instead of using a submodule? It would make maintenance easier for us.